### PR TITLE
[REFACT] Envio de e-mails apenas para pacientes ativos

### DIFF
--- a/backend/src/enviarEmail.js
+++ b/backend/src/enviarEmail.js
@@ -23,6 +23,7 @@ module.exports = async function enviaEmail(){
         { $eq: [{ $dayOfMonth: "$dtNascimento" }, dataAtual.getDate()] },
       ],
     },
+    ativo: true
   });
 
   // Envia um e-mail para cada cliente

--- a/backend/src/script.js
+++ b/backend/src/script.js
@@ -1,8 +1,6 @@
 const enviaEmail = require("./enviarEmail.js");
 const cron = require("node-cron");      
 
-console.log('Executei script.js')
-
 //Função 'enviaEmail()' será executada todo dia às 9:00 da manhã.
 cron.schedule("0 9 * * *", () => {
   enviaEmail(); 


### PR DESCRIPTION
## Descrição
Atende ao último critério de aceitação da User Story 24: enviar e-mails apenas para os pacientes com status ativo.

## Issues Relacionadas
- #55 

## Mudanças Propostas

- A busca na base de dados por pacientes leva em consideração mais uma condição: o status do paciente ser ativo.

## Observações

Como até o momento desse PR a página 'Editar Paciente' não está implementada, siga esse passo-a-passo para testar a funcionalidade.

### Passo 1 - Cadastre um paciente no banco de dados com a data de aniversário igual ao dia atual

O e-mail deve ser um e-mail que você tem acesso.

### Passo 2 - Ative a função 'enviaEmail()' em 'script.js' fora do horário programado.

![image](https://github.com/mdsreq-fga-unb/2023.2-NutriPlanner/assets/54083088/51140b17-15fb-41dc-a635-34fda550c7d4)

### Passo 3 - Rode o backend

Repare que será enviado o e-mail de felicitação.

### Passo 4 - No banco de dados, altere o estado de ativo para 'false'

#### 4.1 - Localize o paciente no banco de dados e clique no ícone de lápis para editar

![image](https://github.com/mdsreq-fga-unb/2023.2-NutriPlanner/assets/54083088/e96b1db8-8e63-4de3-8269-b00b28024b93)

#### 4.2 - Mude o atributo 'ativo' para 'false'

![image](https://github.com/mdsreq-fga-unb/2023.2-NutriPlanner/assets/54083088/42b701cf-9b01-48f4-b8bf-b791fca2c9f2)

#### 4.3 - Clique no botão 'UPDATE' para salvar a alteração

![image](https://github.com/mdsreq-fga-unb/2023.2-NutriPlanner/assets/54083088/7a2f4957-c5a7-4f29-8030-8ded2e6c4895)

Se a alteração foi feita com sucesso, o MongoDB vai mostrar a seguinte mensagem:

![image](https://github.com/mdsreq-fga-unb/2023.2-NutriPlanner/assets/54083088/f937861e-0a13-430d-b3fd-0f93ed439164)

#### Passo 5 - Rode o backend de novo

Repare que dessa vez o e-mail não será enviado.
